### PR TITLE
Add summary endpoint and initial tests

### DIFF
--- a/1.py
+++ b/1.py
@@ -8,8 +8,8 @@ from datetime import datetime
 app = Flask(__name__)
 
 # API keys
-GEOCLIENT_KEY = '3bd5c70fec6f4c8f9a59821a303eeb72'  # Primary key
-GEOCLIENT_SECONDARY_KEY = '107c23829655446a98802eeceb127c7b'  # Secondary key
+GEOCLIENT_KEY = '3bd5c70fec6f4c8f9a59821a303eeb72'  # Primary Geoclient API key
+GEOCLIENT_SECONDARY_KEY = '107c23829655446a98802eeceb127c7b'  # Secondary Geoclient API key
 GOOGLE_KEY = 'AIzaSyDBCR8XDh6aVnm0JaQGH4pLzG_KXy2Nsro'
 
 
@@ -89,7 +89,10 @@ def get_pip_docs(bc, block, lot):
 
 def generate_tax_url(bc, block, lot):
     pin = f"{int(bc)}{block}{lot}"
-    return f"https://a836-pts-access.nyc.gov/care/datalets/datalet.aspx?mode=profileall2&s&UseSearch=no&pin={pin}&jur=65"
+    return (
+        "https://a836-pts-access.nyc.gov/care/datalets/datalet.aspx?"
+        f"mode=profileall2&UseSearch=no&pin={pin}&jur=65"
+    )
 
 @app.route('/')
 def index():
@@ -132,6 +135,14 @@ def index():
         geoclient_raw=geoclient_raw,
         tax_url=tax_url
     )
+
+
+@app.route('/summary', methods=['POST'])
+def summary():
+    data = request.get_json(silent=True) or {}
+    docs = data.get('docs', [])
+    lines = [f"{d.get('recorded_datetime')} - {d.get('doc_type')}" for d in docs]
+    return jsonify(summary=lines)
 
 HTML_TEMPLATE = '''
 <!doctype html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+requests
+pytest

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,24 @@
+import importlib.util
+import json
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location('app_module', Path(__file__).resolve().parents[1] / '1.py')
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+app = mod.app
+generate_tax_url = mod.generate_tax_url
+
+def test_generate_tax_url():
+    url = generate_tax_url('3', '12345', '1001')
+    assert url == (
+        "https://a836-pts-access.nyc.gov/care/datalets/datalet.aspx"
+        "?mode=profileall2&UseSearch=no&pin=3123451001&jur=65"
+    )
+
+def test_summary_endpoint():
+    client = app.test_client()
+    docs = [{"doc_type": "DEED", "recorded_datetime": "01/01/2024"}]
+    resp = client.post('/summary', json={'docs': docs})
+    assert resp.status_code == 200
+    data = json.loads(resp.data)
+    assert data["summary"] == ["01/01/2024 - DEED"]


### PR DESCRIPTION
## Summary
- clarify API key comments
- fix stray `s` parameter in tax URL
- implement `/summary` endpoint
- add pytest tests and requirements file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af46727848324888b440299f6665d